### PR TITLE
fix(ios): add @autoreleasepool in hippy custom js thread callback block

### DIFF
--- a/ios/sdk/base/HippyBatchedBridge.mm
+++ b/ios/sdk/base/HippyBatchedBridge.mm
@@ -806,11 +806,13 @@ HIPPY_NOT_IMPLEMENTED(- (instancetype)initWithBundleURL:(__unused NSURL *)bundle
             
             //HIPPY_PROFILE_BEGIN_EVENT(0, @"-[HippyBatchedBridge dispatchBlock", @{ @"loading": @(self.loading) });
             
-            if (self.loading) {
-                HippyAssert(self->_pendingCalls != nil, @"Can't add pending call, bridge is no longer loading");
-                [self->_pendingCalls addObject:block];
-            } else {
-                block();
+            @autoreleasepool {
+                if (self.loading) {
+                    HippyAssert(self->_pendingCalls != nil, @"Can't add pending call, bridge is no longer loading");
+                    [self->_pendingCalls addObject:block];
+                } else {
+                    block();
+                }
             }
             
             //HIPPY_PROFILE_END_EVENT(HippyProfileTagAlways, @"");

--- a/ios/sdk/base/HippyRootView.mm
+++ b/ios/sdk/base/HippyRootView.mm
@@ -387,7 +387,7 @@ HIPPY_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
                      args:@[moduleName, appParameters]
                completion:^{
         if ([weakSelf.delegate respondsToSelector:@selector(rootViewRunApplicationFinished:)]) {
-            [weakSelf.delegate rootViewRunApplicationFinished:self];
+            [weakSelf.delegate rootViewRunApplicationFinished:weakSelf];
         }
     }];
 }


### PR DESCRIPTION
Before submitting a new pull request, please make sure:

- [ ] Test cases have been added/updated for the code you will submit.
- [ ] Documentation has added or updated.
- [x] Commit message is following the [Convention Commit](https://conventionalcommits.org/) guideline.
- [x] Squash the repeat code commits, short patches are welcome.
背景:
因为 executeBlockOnJavaScriptQueue 的 block 回调是在 hippy 自己用 pthread 创建的线程里面调用的, 导致编译器不会自动加上 @autoreleasepool , 目前在业务使用过程中发现部分对象被 @autoreleasepool content 持有不释放的问题, 具体可以参考这篇博客: https://satanwoo.github.io/2019/07/02/RevisitAutorelease/
修复建议:
加上 @autoreleasepool, 促使 Objective-C 对象在 ARC 下能够及时释放